### PR TITLE
'port' is now deprecated and potentially ambiguous

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,13 +77,13 @@ ${shortserver}
   }
 
   firewall {'050 allow central backups service ports':
-    port   => $service_ports,
+    dport  => $service_ports,
     action => accept,
     source => $server
   }
 
   firewall {'050 allow central backups connection ports':
-    port   => $connection_ports,
+    dport  => $connection_ports,
     action => accept,
     source => $server
   }


### PR DESCRIPTION
The `port` parameter in `puppetlabs/firewall` is now deprecated and potentially ambiguous, switching to `dport` for clarity
